### PR TITLE
Remove usage of render_to_response to support django 3.0

### DIFF
--- a/django_celery_monitor/admin.py
+++ b/django_celery_monitor/admin.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, unicode_literals
 from django.contrib import admin
 from django.contrib.admin import helpers
 from django.contrib.admin.views import main as main_views
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import RequestContext
 from django.utils.encoding import force_text
 from django.utils.html import escape
@@ -211,7 +211,7 @@ class TaskMonitor(ModelMonitor):
             'app_label': app_label,
         }
 
-        return render_to_response(
+        return render(
             self.rate_limit_confirmation_template, context,
             context_instance=RequestContext(request),
         )


### PR DESCRIPTION
I just replaced call to `render_to_response` by `render` in `admin.py`